### PR TITLE
Update fixed register method

### DIFF
--- a/grpc/src/Server.php
+++ b/grpc/src/Server.php
@@ -106,12 +106,15 @@ final class Server
         return $this;
     }
 
-    public function register(string $class): self
+    public function register(string $class, ServiceInterface $instance = null): self
     {
         if (!class_exists($class)) {
             throw new TypeError("{$class} not found");
         }
-        $instance = new $class();
+        // Only recreate the class if the users dont pass in their initialized class
+        if (!$instance) {
+            $instance = new $class();
+        }
         if (!($instance instanceof ServiceInterface)) {
             throw new TypeError("{$class} is not ServiceInterface");
         }

--- a/grpc/src/ServiceContainer.php
+++ b/grpc/src/ServiceContainer.php
@@ -119,7 +119,7 @@ final class ServiceContainer
         $methods = [];
         foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
             // Check if its a gRPC method before doing this check
-            if (count($method->getParameters()) > 0 && $method->getParameteres()[0]->getName() == "ctx") {
+            if (count($method->getParameters()) > 0 && $method->getParameteres()[0]->getName() == 'ctx') {
                 // This is a gRPC method
                 if ($method->getNumberOfParameters() !== 2) {
                     throw new Exception('error method');

--- a/grpc/src/ServiceContainer.php
+++ b/grpc/src/ServiceContainer.php
@@ -118,15 +118,17 @@ final class ServiceContainer
 
         $methods = [];
         foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
-            if ($method->getNumberOfParameters() !== 2) {
-                throw new Exception('error method');
+            // Check if its a gRPC method before doing this check
+            if (count($method->getParameters()) > 0 && $method->getParameteres()[0]->getName() == "ctx") {
+                // This is a gRPC method
+                if ($method->getNumberOfParameters() !== 2) {
+                    throw new Exception('error method');
+                }
+                [, $input] = $method->getParameters();
+
+                $methods[$method->getName()] = ['name' => $method->getName(), 'inputClass' => $input->getType(), 'returnClass' => $method->getReturnType()];
             }
-
-            [, $input] = $method->getParameters();
-
-            $methods[$method->getName()] = ['name' => $method->getName(), 'inputClass' => $input->getType(), 'returnClass' => $method->getReturnType()];
         }
-
         return $methods;
     }
 }


### PR DESCRIPTION
This fix allows users to pass in an object to be used as an Instance.

The reason is to allow users to create their ServiceInterface and has custom functions, such as `__constructor`.
This is useful if the Class fulfilling the interface needs access to other stuff that needs to be Set or configured.

Added a fix in the ServiceContainer to only check the functions that have the gRPC `ctx` as the first parameter.

Added the ability to allow users to pass in their initialized instances of ServiceInterace on `register`