### PR TITLE
Fix getMessage() implementation per PSR-7

### DIFF
--- a/core/src/Psr/Message.php
+++ b/core/src/Psr/Message.php
@@ -41,7 +41,11 @@ class Message
 
     public function getHeaders()
     {
-        return $this->headers;
+        $headers = [];
+        foreach ($this->headers as $header => $line) {
+            $headers[$header] = is_array($line) ? $line : [$line];
+        }
+        return $headers;
     }
 
     public function hasHeader($name)


### PR DESCRIPTION
getMessage() must always return an array of arrays, not an array of strings ([PSR-7](https://www.php-fig.org/psr/psr-7/#12-http-headers)).

This issue is currently breaking [Sentry RequestIntegration](https://docs.sentry.io/platforms/php/integrations/#requestintegration).

Resolves #21