### PR TITLE
fix : correctly set headers when creating PSR response

### DIFF
--- a/core/src/Psr/Message.php
+++ b/core/src/Psr/Message.php
@@ -142,4 +142,11 @@ class Message
         $message->stream = $stream;
         return $message;
     }
+
+    protected function setHeaders(array $headers): void
+    {
+        $this->headers = $this->withHeaders($headers)
+            ->getHeaders()
+        ;
+    }
 }

--- a/core/src/Psr/Response.php
+++ b/core/src/Psr/Response.php
@@ -97,7 +97,7 @@ class Response extends Message implements ResponseInterface
         $this->stream = is_string($body) ? Stream::streamFor($body) : $body;
         $this->setStatusCode($statusCode);
         $this->setReasonPhrase($reasonPhrase);
-        $this->withHeaders($headers);
+        $this->setHeaders($headers);
         $this->protocolVersion = $protocolVersion;
     }
 

--- a/core/tests/Psr/ResponseTest.php
+++ b/core/tests/Psr/ResponseTest.php
@@ -27,6 +27,15 @@ class ResponseTest extends ResponseIntegrationTest
 {
     public function createSubject()
     {
-        return new Response('');
+        return new Response('', 200, '', ['X-Foo' => 'Bar']);
+    }
+
+    public function testCreationWillSetHeaders(): void
+    {
+        $response = $this->createSubject();
+
+        self::assertEquals(200, $response->getStatusCode());
+        self::assertEquals('OK', $response->getReasonPhrase());
+        self::assertEquals(['x-foo' => ['Bar']], $response->getHeaders());
     }
 }

--- a/example/src/Http/Client.php
+++ b/example/src/Http/Client.php
@@ -25,7 +25,7 @@ if ($type == 'GET') {
     $header .= "\r\n";
     $_sendStr = $header;
 } else {
-//    $header = "POST /home/explore/?hello=123&world=swoole#hello HTTP/1.1\r\n";
+    //    $header = "POST /home/explore/?hello=123&world=swoole#hello HTTP/1.1\r\n";
     $header = "POST /post.php HTTP/1.1\r\n";
     $header .= "Host: 127.0.0.1\r\n";
     $header .= "Referer: http://group.openswoole.com/\r\n";
@@ -37,15 +37,15 @@ if ($type == 'GET') {
 
     $_postData = ['body1' => 'swoole_http-server', 'message' => 'nihao'];
     $_postBody = json_encode($_postData);
-//    $_postBody = http_build_query($_postData);
+    //    $_postBody = http_build_query($_postData);
     $header .= 'Content-Length: ' . strlen($_postBody);
     echo 'http header length=' . strlen($header) . "\n";
     $header .= 'Content-Length: ' . (strlen($_postBody) - 2);
 
-//    $cli->send($header);
-//    usleep(100000);
+    //    $cli->send($header);
+    //    usleep(100000);
     $_sendStr = $header . "\r\n\r\n" . $_postBody;
-//    $_sendStr = "\r\n\r\n" . $_postBody;
+    //    $_sendStr = "\r\n\r\n" . $_postBody;
     echo 'postBody length=' . strlen($_postBody) . "\n";
 }
 


### PR DESCRIPTION
this fixes a bug with the headers not being set, `Message::withHeaders` returns an new object and does not set the underlying headers.