### PR TITLE
Maintain compatibility with PSR

### DIFF
--- a/core/src/Psr/Message.php
+++ b/core/src/Psr/Message.php
@@ -10,14 +10,16 @@ declare(strict_types=1);
 namespace OpenSwoole\Core\Psr;
 
 use InvalidArgumentException;
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\StreamInterface;
 
-class Message
+class Message implements MessageInterface
 {
-    public $headers = [];
+    public array $headers = [];
 
-    protected $protocolVersion = '1.1';
+    protected string $protocolVersion = '1.1';
 
-    protected $stream;
+    protected StreamInterface $body;
 
     public function __construct($stream = null)
     {
@@ -25,22 +27,22 @@ class Message
             $stream = new Stream('php://memory', 'wb+');
         }
 
-        $this->withBody($stream);
+        return $this->withBody($stream);
     }
 
-    public function getProtocolVersion()
+    public function getProtocolVersion(): string
     {
         return $this->protocolVersion;
     }
 
-    public function withProtocolVersion($version)
+    public function withProtocolVersion(string $version): MessageInterface
     {
         $message                  = clone $this;
         $message->protocolVersion = $version;
         return $message;
     }
 
-    public function getHeaders()
+    public function getHeaders(): array
     {
         $headers = [];
         foreach ($this->headers as $header => $line) {
@@ -49,30 +51,26 @@ class Message
         return $headers;
     }
 
-    public function hasHeader($name)
+    public function hasHeader(string $name): bool
     {
         return isset($this->headers[strtolower($name)]);
     }
 
-    public function getHeader($name)
+    public function getHeader(string $name): array
     {
         return $this->hasHeader($name) ? $this->headers[strtolower($name)] : [];
     }
 
-    public function getHeaderLine($name)
+    public function getHeaderLine(string $name): string
     {
         $value = $this->getHeader($name);
 
-        if (empty($value)) {
-            return '';
-        }
-
-        return is_array($value) ? implode(',', $value) : $value;
+        return implode(',', $value);
     }
 
-    public function withHeader($name, $value)
+    public function withHeader(string $name, $value): MessageInterface
     {
-        if (!is_string($name) || !is_string($value) && !is_array($value) || $name === '' || $value !== '' && empty($value)) {
+        if (!is_string($value) && !is_array($value) || $name === '' || $value !== '' && empty($value)) {
             throw new InvalidArgumentException('Header is not validate.');
         }
         $message = clone $this;
@@ -86,7 +84,7 @@ class Message
         return $message;
     }
 
-    public function withHeaders(array $headers)
+    public function withHeaders(array $headers): MessageInterface
     {
         $message = clone $this;
         foreach ($headers as $key => $header) {
@@ -102,9 +100,9 @@ class Message
         return $message;
     }
 
-    public function withAddedHeader($name, $value)
+    public function withAddedHeader(string $name, $value): MessageInterface
     {
-        if (!is_string($name) || !is_string($value) && !is_array($value) || empty($name) || $value !== '' && $value !== '0' && empty($value)) {
+        if (!is_string($value) && !is_array($value) || empty($name) || $value !== '' && $value !== '0' && empty($value)) {
             throw new InvalidArgumentException('Header is not validate.');
         }
         $message = clone $this;
@@ -119,7 +117,7 @@ class Message
         return $message;
     }
 
-    public function withoutHeader($name)
+    public function withoutHeader(string $name): MessageInterface
     {
         $name = strtolower($name);
 
@@ -132,15 +130,15 @@ class Message
         return $this;
     }
 
-    public function getBody()
+    public function getBody(): StreamInterface
     {
-        return $this->stream;
+        return $this->body;
     }
 
-    public function withBody($stream)
+    public function withBody(StreamInterface $body): MessageInterface
     {
         $message         = clone $this;
-        $message->stream = $stream;
+        $message->body   = $body;
         return $message;
     }
 

--- a/core/src/Psr/Request.php
+++ b/core/src/Psr/Request.php
@@ -11,14 +11,15 @@ namespace OpenSwoole\Core\Psr;
 
 use InvalidArgumentException;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
 
 class Request extends Message implements RequestInterface
 {
-    private $method;
+    private ?string $method;
 
-    private $uri;
+    private UriInterface $uri;
 
-    private $requestTarget;
+    private ?string $requestTarget;
 
     public function __construct($uri, string $method = null, $body = null, array $headers = [], string $protocolVersion = '1.1')
     {
@@ -41,7 +42,7 @@ class Request extends Message implements RequestInterface
         return $this->method;
     }
 
-    public function withMethod($method): self
+    public function withMethod($method): RequestInterface
     {
         if (!is_string($method)) {
             throw new InvalidArgumentException('Method is not validate.');
@@ -51,12 +52,12 @@ class Request extends Message implements RequestInterface
         return $request;
     }
 
-    public function getUri()
+    public function getUri(): UriInterface
     {
         return $this->uri;
     }
 
-    public function withUri($uri, $preserveHost = false): self
+    public function withUri($uri, $preserveHost = false): RequestInterface
     {
         if ($uri === $this->uri) {
             return $this;
@@ -101,7 +102,7 @@ class Request extends Message implements RequestInterface
         return $target;
     }
 
-    public function withRequestTarget($requestTarget): self
+    public function withRequestTarget(string $requestTarget): RequestInterface
     {
         if (preg_match('/\s/', $requestTarget)) {
             throw new InvalidArgumentException('Request target can\'t contain whitespaces');

--- a/core/src/Psr/Request.php
+++ b/core/src/Psr/Request.php
@@ -30,9 +30,9 @@ class Request extends Message implements RequestInterface
             $stream = new Stream('php://memory', 'wb+');
             $this->withBody($stream);
         } elseif (is_resource($body)) {
-            $this->stream = new Stream($body);
+            $this->body = new Stream($body);
         } else {
-            $this->stream = Stream::streamFor($body);
+            $this->body = Stream::streamFor($body);
         }
     }
 

--- a/core/src/Psr/Response.php
+++ b/core/src/Psr/Response.php
@@ -95,7 +95,7 @@ class Response extends Message implements ResponseInterface
 
     public function __construct($body, int $statusCode = 200, string $reasonPhrase = '', array $headers = [], string $protocolVersion = '1.1')
     {
-        $this->stream = is_string($body) ? Stream::streamFor($body) : $body;
+        $this->body = is_string($body) ? Stream::streamFor($body) : $body;
         $this->setStatusCode($statusCode);
         $this->setReasonPhrase($reasonPhrase);
         $this->setHeaders($headers);

--- a/core/src/Psr/ServerRequest.php
+++ b/core/src/Psr/ServerRequest.php
@@ -14,17 +14,17 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class ServerRequest extends Request implements ServerRequestInterface
 {
-    protected $attributes = [];
+    protected array $attributes = [];
 
-    protected $cookieParams = [];
+    protected array $cookieParams = [];
 
-    protected $serverParams = [];
+    protected array $serverParams = [];
 
-    protected $queryParams;
+    protected array $queryParams;
 
-    protected $uploadedFiles;
+    protected array $uploadedFiles;
 
-    protected $parsedBody;
+    protected mixed $parsedBody;
 
     public function __construct(
         $uri,
@@ -47,7 +47,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         $this->parsedBody    = $parsedBody;
     }
 
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return $this->attributes;
     }
@@ -57,14 +57,14 @@ class ServerRequest extends Request implements ServerRequestInterface
         return $this->hasAttribute($name) ? $this->attributes[$name] : $default;
     }
 
-    public function withAttribute($name, $value)
+    public function withAttribute($name, $value): ServerRequestInterface
     {
         $request                    = clone $this;
         $request->attributes[$name] = $value;
         return $request;
     }
 
-    public function withoutAttribute($name)
+    public function withoutAttribute($name): ServerRequestInterface
     {
         if (!isset($this->attributes[$name])) {
             return $this;
@@ -80,25 +80,25 @@ class ServerRequest extends Request implements ServerRequestInterface
         return $this->serverParams;
     }
 
-    public function withServerParams(array $server)
+    public function withServerParams(array $server): static
     {
         $this->serverParams = $server;
         return $this;
     }
 
-    public function withCookieParams(array $cookies)
+    public function withCookieParams(array $cookies): ServerRequestInterface
     {
         $request               = clone $this;
         $request->cookieParams = $cookies;
         return $request;
     }
 
-    public function getCookieParams()
+    public function getCookieParams(): array
     {
         return $this->cookieParams;
     }
 
-    public function getQueryParams()
+    public function getQueryParams(): array
     {
         return $this->queryParams;
     }
@@ -112,19 +112,19 @@ class ServerRequest extends Request implements ServerRequestInterface
         return $default;
     }
 
-    public function withQueryParams(array $query)
+    public function withQueryParams(array $query): ServerRequest
     {
         $request              = clone $this;
         $request->queryParams = $query;
         return $request;
     }
 
-    public function getUploadedFiles()
+    public function getUploadedFiles(): array
     {
         return $this->uploadedFiles;
     }
 
-    public function withUploadedFiles(array $uploadedFiles)
+    public function withUploadedFiles(array $uploadedFiles): ServerRequest
     {
         $request                = clone $this;
         $request->uploadedFiles = $uploadedFiles;
@@ -136,7 +136,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         return $this->parsedBody;
     }
 
-    public function withParsedBody($data)
+    public function withParsedBody($data): ServerRequest
     {
         if (!is_array($data) && !is_object($data) && !is_null($data)) {
             throw new InvalidArgumentException('Error HTTP body.');
@@ -146,7 +146,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         return $request;
     }
 
-    public static function from(\OpenSwoole\HTTP\Request $request)
+    public static function from(\OpenSwoole\HTTP\Request $request): ServerRequest
     {
         $files = [];
 
@@ -167,8 +167,8 @@ class ServerRequest extends Request implements ServerRequestInterface
             $request->server['request_method'],
             $request->rawContent() ? $request->rawContent() : 'php://memory',
             $request->header,
-            isset($request->cookie) ? $request->cookie : [],
-            isset($request->get) ? $request->get : [],
+            $request->cookie ?? [],
+            $request->get ?? [],
             $request->server,
             $files,
         );

--- a/core/src/Psr/ServerRequest.php
+++ b/core/src/Psr/ServerRequest.php
@@ -52,19 +52,19 @@ class ServerRequest extends Request implements ServerRequestInterface
         return $this->attributes;
     }
 
-    public function getAttribute($name, $default = null)
+    public function getAttribute(string $name, $default = null)
     {
         return $this->hasAttribute($name) ? $this->attributes[$name] : $default;
     }
 
-    public function withAttribute($name, $value): ServerRequestInterface
+    public function withAttribute(string $name, $value): ServerRequestInterface
     {
         $request                    = clone $this;
         $request->attributes[$name] = $value;
         return $request;
     }
 
-    public function withoutAttribute($name): ServerRequestInterface
+    public function withoutAttribute(string $name): ServerRequestInterface
     {
         if (!isset($this->attributes[$name])) {
             return $this;
@@ -80,7 +80,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         return $this->serverParams;
     }
 
-    public function withServerParams(array $server): static
+    public function withServerParams(array $server): ServerRequestInterface
     {
         $this->serverParams = $server;
         return $this;
@@ -112,7 +112,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         return $default;
     }
 
-    public function withQueryParams(array $query): ServerRequest
+    public function withQueryParams(array $query): ServerRequestInterface
     {
         $request              = clone $this;
         $request->queryParams = $query;
@@ -124,7 +124,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         return $this->uploadedFiles;
     }
 
-    public function withUploadedFiles(array $uploadedFiles): ServerRequest
+    public function withUploadedFiles(array $uploadedFiles): ServerRequestInterface
     {
         $request                = clone $this;
         $request->uploadedFiles = $uploadedFiles;
@@ -136,7 +136,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         return $this->parsedBody;
     }
 
-    public function withParsedBody($data): ServerRequest
+    public function withParsedBody($data): ServerRequestInterface
     {
         if (!is_array($data) && !is_object($data) && !is_null($data)) {
             throw new InvalidArgumentException('Error HTTP body.');
@@ -146,7 +146,7 @@ class ServerRequest extends Request implements ServerRequestInterface
         return $request;
     }
 
-    public static function from(\OpenSwoole\HTTP\Request $request): ServerRequest
+    public static function from(\OpenSwoole\HTTP\Request $request): ServerRequestInterface
     {
         $files = [];
 


### PR DESCRIPTION
Make "Message.php" declarations compatible with "Psr\Http\Message\MessageInterface" to avoid fatal error in swoole:latest docker image.
This PR Resolves #63, resolves #72.