### PR TITLE
Added aliases for co and go

### DIFF
--- a/ide-helper/composer.json
+++ b/ide-helper/composer.json
@@ -9,6 +9,12 @@
             "email": "hello@openswoole.com"
         }
     ],
+    "autoload": {
+        "files": ["src/functions.php"],
+        "psr-4": {
+            "OpenSwoole\\": "src"
+        }
+    },
     "require": {
         "php": ">=7.4",
         "ext-openswoole": ">=22.0"

--- a/ide-helper/composer.json
+++ b/ide-helper/composer.json
@@ -12,7 +12,7 @@
     "autoload": {
         "files": ["src/functions.php"],
         "psr-4": {
-            "OpenSwoole\\": "src"
+            "OpenSwoole\\": "src/"
         }
     },
     "require": {

--- a/ide-helper/src/OpenSwoole/Coroutine.php
+++ b/ide-helper/src/OpenSwoole/Coroutine.php
@@ -40,6 +40,12 @@ final class Coroutine
 
     /**
      * @param callable $callback [required]
+     * @return void
+     */
+    public static function go(callable $callback) {}
+
+    /**
+     * @param callable $callback [required]
      */
     public static function defer(callable $callback): void {}
 

--- a/ide-helper/src/functions.php
+++ b/ide-helper/src/functions.php
@@ -1,0 +1,11 @@
+<?php
+
+function go(callable $coroutine): void
+{
+    OpenSwoole\Coroutine::go($coroutine);
+}
+
+class co
+{
+    public static function run(callable $callback) {}
+}


### PR DESCRIPTION
I propose to add aliases for co and go constructions in a separate functions file to exclude them from namespace.
If it works then chan and defer also can be added this way to prevent IDE from complaining about missing functions:
![image](https://github.com/openswoole/ide-helper/assets/974975/f9e5ef1e-4015-478c-8643-7ffcf112f4bc)