### PR TITLE
FIX - Request header not reutnring array

### DIFF
--- a/core/src/Psr/Request.php
+++ b/core/src/Psr/Request.php
@@ -25,7 +25,7 @@ class Request extends Message implements RequestInterface
     {
         $this->uri             = is_string($uri) ? new Uri($uri) : $uri;
         $this->method          = $method;
-        $this->headers         = $headers;
+        $this->setHeaders($headers);
         $this->protocolVersion = $protocolVersion;
         if ($body === null) {
             $stream = new Stream('php://memory', 'wb+');
@@ -86,7 +86,7 @@ class Request extends Message implements RequestInterface
 
     public function getRequestTarget(): string
     {
-        if ($this->requestTarget !== null) {
+        if (isset($this->requestTarget)) {
             return $this->requestTarget;
         }
 

--- a/core/tests/Psr/RequestTest.php
+++ b/core/tests/Psr/RequestTest.php
@@ -18,6 +18,7 @@ namespace OpenSwoole\Core\Psr7Test\Tests;
 
 use Http\Psr7Test\RequestIntegrationTest;
 use OpenSwoole\Core\Psr\Request;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * @internal
@@ -25,8 +26,13 @@ use OpenSwoole\Core\Psr\Request;
  */
 class RequestTest extends RequestIntegrationTest
 {
-    public function createSubject()
+    public function createSubject(): RequestInterface
     {
-        return new Request('/', 'GET');
+        return new Request('/', 'GET', null, ['X-Foo' => 'Bar']);
+    }
+
+    public function testGetHeader(): void
+    {
+        $this->assertEquals(['Bar'], $this->request->getHeader('X-Foo'));
     }
 }


### PR DESCRIPTION
The `Request::getHeader` was not returning an array when header values were set without using the `Message::setHeaders` method.

Additionally, the Psr7Tests for the Request were failing. Changed getRequestTarget to use isset instead of null.