### PR TITLE
feat: update IDE helper stubs for ext-openswoole 26.2.0

### DIFF
--- a/ide-helper/src/OpenSwoole/Atomic.php
+++ b/ide-helper/src/OpenSwoole/Atomic.php
@@ -21,14 +21,14 @@ class Atomic
     /**
      * @param int $value [optional] = 1
      */
-    public function add(int $value = 1): int
+    public function add(int $value = 1): int|bool
     {
     }
 
     /**
      * @param int $value [optional] = 1
      */
-    public function sub(int $value = 1): int
+    public function sub(int $value = 1): int|bool
     {
     }
 

--- a/ide-helper/src/OpenSwoole/Client.php
+++ b/ide-helper/src/OpenSwoole/Client.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace OpenSwoole;
 
+use Socket;
+
 class Client
 {
     public const MSG_OOB = 1;
@@ -41,10 +43,10 @@ class Client
 
     /**
      * @param int $sockType [required]
-     * @param bool $async [optional] = false
+     * @param int|bool $async [optional] = false
      * @param string $id [optional] = ''
      */
-    public function __construct(int $sockType, bool $async = false, string $id = '')
+    public function __construct(int $sockType, int|bool $async = false, string $id = '')
     {
     }
 
@@ -73,7 +75,7 @@ class Client
      * @param int $length [optional] = 65535
      * @param int $flags [optional] = 0
      */
-    public function recv(int $length = 65535, int $flags = 0): string
+    public function recv(int $length = 65535, int $flags = 0): bool|string
     {
     }
 
@@ -81,7 +83,7 @@ class Client
      * @param string $data [required]
      * @param int $flags [optional] = 0
      */
-    public function send(string $data, int $flags = 0)
+    public function send(string $data, int $flags = 0): bool|int
     {
     }
 
@@ -114,7 +116,7 @@ class Client
     {
     }
 
-    public function getPeerCert(): string
+    public function getPeerCert(): bool|string
     {
     }
 
@@ -138,6 +140,10 @@ class Client
      * @param bool $force [optional] = false
      */
     public function close(bool $force = false): bool
+    {
+    }
+
+    public function getSocket(): Socket|false
     {
     }
 

--- a/ide-helper/src/OpenSwoole/Constant.php
+++ b/ide-helper/src/OpenSwoole/Constant.php
@@ -11,17 +11,19 @@ namespace OpenSwoole;
 
 class Constant
 {
-    public const VERSION = '22.0.0-dev';
+    public const VERSION = '26.2.0';
 
-    public const VERSION_ID = 220000;
+    public const VERSION_ID = 260200;
 
-    public const MAJOR_VERSION = 22;
+    public const MAJOR_VERSION = 26;
 
-    public const MINOR_VERSION = 0;
+    public const MINOR_VERSION = 2;
 
     public const RELEASE_VERSION = 0;
 
-    public const EXTRA_VERSION = 'dev';
+    public const EXTRA_VERSION = '';
+
+    public const HAVE_DEBUG = 0;
 
     public const HAVE_COMPRESSION = 1;
 
@@ -135,6 +137,21 @@ class Constant
     public const SSL_DTLS = 128;
 
     public const SSL_SSLv2 = 2;
+
+    public const SSL_SSLv3 = 4;
+
+    /**
+     * Reactor type constants
+     */
+    public const REACTOR_SELECT = 0;
+
+    public const REACTOR_POLL = 1;
+
+    public const REACTOR_EPOLL = 2;
+
+    public const REACTOR_KQUEUE = 3;
+
+    public const REACTOR_IO_URING = 4;
 
     /**
      * Register ERROR types

--- a/ide-helper/src/OpenSwoole/Coroutine.php
+++ b/ide-helper/src/OpenSwoole/Coroutine.php
@@ -34,9 +34,8 @@ final class Coroutine
 
     /**
      * @param callable $callback [required]
-     * @return int|false
      */
-    public static function create(callable $callback, ...$params)
+    public static function create(callable $callback, ...$params): int|false
     {
     }
 
@@ -50,7 +49,7 @@ final class Coroutine
     /**
      * @param array $options [required]
      */
-    public static function set(array $options)
+    public static function set(array $options): mixed
     {
     }
 
@@ -80,10 +79,6 @@ final class Coroutine
     {
     }
 
-    public static function suspend(): bool
-    {
-    }
-
     /**
      * @param int $cid [required]
      */
@@ -95,15 +90,11 @@ final class Coroutine
     {
     }
 
-    public static function select(array $read = [], array $write = [], float $timeout = -1)
+    public static function select(array $read = [], array $write = [], float $timeout = -1): mixed
     {
     }
 
     public static function getCid(): int
-    {
-    }
-
-    public static function getuid(): int
     {
     }
 
@@ -125,9 +116,8 @@ final class Coroutine
      * @param int $cid [optional] = 0
      * @param int $options [optional] = \DEBUG_BACKTRACE_PROVIDE_OBJECT
      * @param int $limit [optional] = 0
-     * @return array|false
      */
-    public static function getBackTrace(int $cid = 0, int $options = DEBUG_BACKTRACE_PROVIDE_OBJECT, int $limit = 0)
+    public static function getBackTrace(int $cid = 0, int $options = DEBUG_BACKTRACE_PROVIDE_OBJECT, int $limit = 0): array|false
     {
     }
 
@@ -150,7 +140,7 @@ final class Coroutine
     /**
      * @param int $cid [optional] = 0
      */
-    public static function getStackUsage(int $cid = 0)
+    public static function getStackUsage(int $cid = 0): int|false
     {
     }
 
@@ -170,27 +160,24 @@ final class Coroutine
      * @param string $domain [required]
      * @param int $family [optional] = \AF_INET
      * @param float $timeout [optional] = -1
-     * @return string|false
      */
-    public static function gethostbyname(string $domain, int $family = AF_INET, float $timeout = -1)
+    public static function gethostbyname(string $domain, int $family = AF_INET, float $timeout = -1): string|false
     {
     }
 
     /**
      * @param string $domain [required]
      * @param float $timeout [optional] = 5
-     * @return string|false
      */
-    public static function dnsLookup(string $domain, float $timeout = 5)
+    public static function dnsLookup(string $domain, float $timeout = 5): string|false
     {
     }
 
     /**
      * @param string $command [required]
      * @param bool $get_error_stream [optional] = false
-     * @return array|false
      */
-    public static function exec(string $command, bool $get_error_stream = false)
+    public static function exec(string $command, bool $get_error_stream = false): array|false
     {
     }
 
@@ -202,9 +189,9 @@ final class Coroutine
     }
 
     /**
-     * @param int $milliseconds [required]
+     * @param int $microseconds [required]
      */
-    public static function usleep(int $milliseconds): bool
+    public static function usleep(int $microseconds): bool
     {
     }
 
@@ -215,26 +202,23 @@ final class Coroutine
      * @param int $protocol [optional] = \STREAM_IPPROTO_TCP
      * @param string $service [optional] = null
      * @param float $timeout [optional] = -1
-     * @return array|false
      */
-    public static function getaddrinfo(string $domain, int $family = AF_INET, int $sockType = SOCK_STREAM, int $protocol = STREAM_IPPROTO_TCP, ?string $service = null, float $timeout = -1)
+    public static function getaddrinfo(string $domain, int $family = AF_INET, int $sockType = SOCK_STREAM, int $protocol = STREAM_IPPROTO_TCP, ?string $service = null, float $timeout = -1): array|false
     {
     }
 
     /**
      * @param string $path [required]
-     * @return array|false
      */
-    public static function statvfs(string $path)
+    public static function statvfs(string $path): bool|array
     {
     }
 
     /**
      * @param string $filename [required]
      * @param int $flags [optional] = 0
-     * @return string|false
      */
-    public static function readFile(string $filename, int $flags = 0)
+    public static function readFile(string $filename, int $flags = 0): false|string
     {
     }
 
@@ -243,24 +227,22 @@ final class Coroutine
      * @param string $data [required]
      * @param int $flags [optional] = 0
      */
-    public static function writeFile(string $filename, string $data, int $flags = 0): bool
+    public static function writeFile(string $filename, string $data, int $flags = 0): bool|int
     {
     }
 
     /**
      * @param float $timeout [optional] = -1
-     * @return array|false
      */
-    public static function wait(float $timeout = -1)
+    public static function wait(float $timeout = -1): bool|array
     {
     }
 
     /**
      * @param int $pid [required]
      * @param float $timeout [optional] = -1
-     * @return array|false
      */
-    public static function waitPid(int $pid, float $timeout = -1)
+    public static function waitPid(int $pid, float $timeout = -1): bool|array
     {
     }
 
@@ -276,33 +258,16 @@ final class Coroutine
      * @param mixed $fd [required]
      * @param int $events [required]
      * @param float $timeout [optional] = -1
-     * @return int|false
      */
-    public static function waitEvent($fd, int $events, float $timeout = -1)
+    public static function waitEvent($fd, int $events, float $timeout = -1): bool|int
     {
     }
 
-    /**
-     * @param mixed $handle [required]
-     * @param int $length [optional] = 0
-     */
-    public static function fread($handle, int $length = 0)
+    public static function clearDNSCache(): void
     {
     }
 
-    /**
-     * @param mixed $handle [required]
-     * @param string $data [required]
-     * @param int $length [optional] = 0
-     */
-    public static function fwrite($handle, string $data, int $length = 0)
-    {
-    }
-
-    /**
-     * @param mixed $handle [required]
-     */
-    public static function fgets($handle): string
+    public static function run(callable $callback, mixed ...$params): ?bool
     {
     }
 }

--- a/ide-helper/src/OpenSwoole/Coroutine/Client.php
+++ b/ide-helper/src/OpenSwoole/Coroutine/Client.php
@@ -64,14 +64,14 @@ final class Client
     /**
      * @param float $timeout [optional] = 1
      */
-    public function recv(float $timeout = 1): string
+    public function recv(float $timeout = 1): bool|string
     {
     }
 
     /**
      * @param int $length [optional] = 65535
      */
-    public function peek(int $length = 65535): string
+    public function peek(int $length = 65535): bool|string
     {
     }
 
@@ -79,7 +79,7 @@ final class Client
      * @param string $data [required]
      * @param float $timeout [optional] = 1
      */
-    public function send(string $data, float $timeout = 1)
+    public function send(string $data, float $timeout = 1): bool|int
     {
     }
 
@@ -106,7 +106,7 @@ final class Client
      * @param mixed $host [required]
      * @param mixed $port [optional] = 0
      */
-    public function recvfrom(int $length, &$host, &$port = 0): string
+    public function recvfrom(int $length, &$host, &$port = 0): bool|string
     {
     }
 
@@ -114,7 +114,7 @@ final class Client
     {
     }
 
-    public function getPeerCert(): string
+    public function getPeerCert(): bool|string
     {
     }
 
@@ -141,10 +141,7 @@ final class Client
     {
     }
 
-    /**
-     * @return Socket|bool
-     */
-    public function exportSocket()
+    public function exportSocket(): Socket|bool
     {
     }
 }

--- a/ide-helper/src/OpenSwoole/Coroutine/Http/Client.php
+++ b/ide-helper/src/OpenSwoole/Coroutine/Http/Client.php
@@ -87,21 +87,21 @@ final class Client
     /**
      * @param bool $defer [optional]
      */
-    public function setDefer(bool $defer = true): void
+    public function setDefer(bool $defer = true): bool
     {
     }
 
     /**
      * @param mixed $method [required]
      */
-    public function setMethod(string $method): void
+    public function setMethod(string $method): bool
     {
     }
 
     /**
      * @param array $headers [required]
      */
-    public function setHeaders(array $headers): void
+    public function setHeaders(array $headers): bool
     {
     }
 
@@ -109,21 +109,21 @@ final class Client
      * @param mixed $username [required]
      * @param mixed $password [required]
      */
-    public function setBasicAuth(string $username, string $password): void
+    public function setBasicAuth(string $username, string $password): ?bool
     {
     }
 
     /**
      * @param array $cookies [required]
      */
-    public function setCookies(array $cookies): void
+    public function setCookies(array $cookies): bool
     {
     }
 
     /**
      * @param string|array $data [required]
      */
-    public function setData($data): void
+    public function setData(string|array $data): bool
     {
     }
 
@@ -151,9 +151,8 @@ final class Client
 
     /**
      * @param string $path [required]
-     * @return int|bool
      */
-    public function execute(string $path)
+    public function execute(string $path): int|bool
     {
     }
 
@@ -174,7 +173,7 @@ final class Client
     /**
      * @param string $path [required]
      */
-    public function get(string $path): void
+    public function get(string $path): bool
     {
     }
 
@@ -182,7 +181,7 @@ final class Client
      * @param mixed $path [required]
      * @param string|array $data [required]
      */
-    public function post(string $path, $data): void
+    public function post(string $path, $data): bool
     {
     }
 

--- a/ide-helper/src/OpenSwoole/Coroutine/Http2/Client.php
+++ b/ide-helper/src/OpenSwoole/Coroutine/Http2/Client.php
@@ -89,7 +89,7 @@ class Client
     {
     }
 
-    public function set(array $options): void
+    public function set(array $options): bool
     {
     }
 
@@ -100,7 +100,7 @@ class Client
     /**
      * @return array|bool|int
      */
-    public function stats(?string $key = null)
+    public function stats(string $key = '')
     {
     }
 
@@ -108,10 +108,7 @@ class Client
     {
     }
 
-    /**
-     * @return int|bool
-     */
-    public function send(Request $request)
+    public function send(Request $request): bool|int
     {
     }
 
@@ -119,17 +116,11 @@ class Client
     {
     }
 
-    /**
-     * @return Response|false
-     */
-    public function recv(?float $timeout = 0)
+    public function recv(?float $timeout = 0): Response|bool
     {
     }
 
-    /**
-     * @return Response|false
-     */
-    public function read(?float $timeout = 0)
+    public function read(?float $timeout = 0): Response|bool
     {
     }
 

--- a/ide-helper/src/OpenSwoole/Coroutine/PostgreSQL.php
+++ b/ide-helper/src/OpenSwoole/Coroutine/PostgreSQL.php
@@ -11,16 +11,6 @@ namespace OpenSwoole\Coroutine;
 
 class PostgreSQL
 {
-    public $error;
-
-    public $errCode;
-
-    public $resultStatus;
-
-    public $resultDiag;
-
-    public $notices;
-
     public function __construct()
     {
     }
@@ -29,135 +19,55 @@ class PostgreSQL
     {
     }
 
-    /**
-     * @param mixed $conninfo [required]
-     */
-    public function connect($conninfo)
+    public function connect(string $conninfo, float $timeout = 2): bool
+    {
+    }
+
+    public function query(string $query): false|PostgreSQLStatement
+    {
+    }
+
+    public function prepare(string $query): false|PostgreSQLStatement
+    {
+    }
+
+    public function escape(string $string): false|string
+    {
+    }
+
+    public function escapeLiteral(string $string): false|string
+    {
+    }
+
+    public function escapeIdentifier(string $string): false|string
+    {
+    }
+
+    public function metaData(string $table_name): false|array
+    {
+    }
+
+    public function createLOB(): int|false
     {
     }
 
     /**
-     * @param mixed $query [optional]
+     * @param string $mode [optional] = "rb"
+     * @return resource|false
      */
-    public function query($query)
+    public function openLOB(int $oid, string $mode = 'rb')
     {
     }
 
-    /**
-     * @param mixed $stmtname [required]
-     * @param mixed $query [required]
-     */
-    public function prepare($stmtname, $query)
+    public function unlinkLOB(int $oid): bool
     {
     }
 
-    /**
-     * @param mixed $stmtname [required]
-     * @param mixed $pv_param_arr [required]
-     */
-    public function execute($stmtname, $pv_param_arr)
+    public function status(): int|false
     {
     }
 
-    /**
-     * @param mixed $result [optional]
-     * @param mixed $result_type [optional]
-     */
-    public function fetchAll($result, $result_type)
-    {
-    }
-
-    /**
-     * @param mixed $result [optional]
-     */
-    public function affectedRows($result)
-    {
-    }
-
-    /**
-     * @param mixed $result [optional]
-     */
-    public function numRows($result)
-    {
-    }
-
-    /**
-     * @param mixed $result [optional]
-     */
-    public function fieldCount($result)
-    {
-    }
-
-    /**
-     * @param mixed $table_name [required]
-     */
-    public function metaData($table_name)
-    {
-    }
-
-    /**
-     * @param mixed $string [required]
-     */
-    public function escape($string)
-    {
-    }
-
-    /**
-     * @param mixed $string [required]
-     */
-    public function escapeLiteral($string)
-    {
-    }
-
-    /**
-     * @param mixed $string [required]
-     */
-    public function escapeIdentifier($string)
-    {
-    }
-
-    /**
-     * @param mixed $result [required]
-     * @param mixed $row [optional]
-     * @param mixed $class_name [optional]
-     * @param mixed $l [optional]
-     * @param mixed $ctor_params [optional]
-     */
-    public function fetchObject($result, $row, $class_name, $l, $ctor_params)
-    {
-    }
-
-    /**
-     * @param mixed $result [required]
-     * @param mixed $row [optional]
-     */
-    public function fetchAssoc($result, $row)
-    {
-    }
-
-    /**
-     * @param mixed $result [required]
-     * @param mixed $row [optional]
-     * @param mixed $result_type [optional]
-     */
-    public function fetchArray($result, $row, $result_type)
-    {
-    }
-
-    /**
-     * @param mixed $result [required]
-     * @param mixed $row [optional]
-     * @param mixed $result_type [optional]
-     */
-    public function fetchRow($result, $row, $result_type)
-    {
-    }
-
-    public function reset()
-    {
-    }
-
-    public function status()
+    public function reset(float $timeout = 0): bool
     {
     }
 }

--- a/ide-helper/src/OpenSwoole/Coroutine/PostgreSQLStatement.php
+++ b/ide-helper/src/OpenSwoole/Coroutine/PostgreSQLStatement.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of OpenSwoole.
+ * @link     https://openswoole.com
+ * @contact  hello@openswoole.com
+ */
+
+namespace OpenSwoole\Coroutine;
+
+class PostgreSQLStatement
+{
+    public function execute(array $params = []): bool
+    {
+    }
+
+    public function fetchAll(int $result_type = 2): false|array
+    {
+    }
+
+    public function fetchObject(?int $row = null, ?string $class_name = null, array $ctor_params = []): false|object
+    {
+    }
+
+    public function fetchAssoc(?int $row = null): false|array
+    {
+    }
+
+    public function fetchArray(?int $row = null, int $result_type = 3): false|array
+    {
+    }
+
+    public function fetchRow(?int $row = null, int $result_type = 1): false|array
+    {
+    }
+
+    public function affectedRows(): false|int
+    {
+    }
+
+    public function numRows(): false|int
+    {
+    }
+
+    public function fieldCount(): false|int
+    {
+    }
+}

--- a/ide-helper/src/OpenSwoole/Coroutine/Socket.php
+++ b/ide-helper/src/OpenSwoole/Coroutine/Socket.php
@@ -56,7 +56,7 @@ class Socket
     /**
      * @param float $timeout [optional] = 0
      */
-    public function accept(float $timeout = 0)
+    public function accept(float $timeout = 0): Socket|false
     {
     }
 
@@ -84,7 +84,7 @@ class Socket
      * @param int $length [optional] = 65536
      * @param float $timeout [optional] = 0
      */
-    public function recv(int $length = 65536, float $timeout = 0): string
+    public function recv(int $length = 65536, float $timeout = 0): bool|string
     {
     }
 
@@ -92,7 +92,7 @@ class Socket
      * @param int $length [optional] = 65536
      * @param float $timeout [optional] = 0
      */
-    public function recvAll(int $length = 65536, float $timeout = 0): string
+    public function recvAll(int $length = 65536, float $timeout = 0): bool|string
     {
     }
 
@@ -246,6 +246,10 @@ class Socket
      * @return bool|array
      */
     public function getsockname()
+    {
+    }
+
+    public function sslHandshake(): bool
     {
     }
 }

--- a/ide-helper/src/OpenSwoole/Coroutine/System.php
+++ b/ide-helper/src/OpenSwoole/Coroutine/System.php
@@ -38,7 +38,7 @@ final class System
      * @param string $command [required]
      * @param bool $get_error_stream [optional] = false
      */
-    public static function exec(string $command, bool $get_error_stream = false): array
+    public static function exec(string $command, bool $get_error_stream = false): array|false
     {
     }
 
@@ -50,9 +50,9 @@ final class System
     }
 
     /**
-     * @param int $milliseconds [required]
+     * @param int $microseconds [required]
      */
-    public static function usleep(int $milliseconds): bool
+    public static function usleep(int $microseconds): bool
     {
     }
 
@@ -80,9 +80,8 @@ final class System
     /**
      * @param string $filename [required]
      * @param int $flags [optional] = 0
-     * @return string|false
      */
-    public static function readFile(string $filename, int $flags = 0): bool
+    public static function readFile(string $filename, int $flags = 0): false|string
     {
     }
 
@@ -91,7 +90,7 @@ final class System
      * @param string $data [required]
      * @param int $flags [optional] = 0
      */
-    public static function writeFile(string $filename, string $data, int $flags = 0): bool
+    public static function writeFile(string $filename, string $data, int $flags = 0): bool|int
     {
     }
 
@@ -124,33 +123,12 @@ final class System
      * @param mixed $fd [required]
      * @param int $events [required]
      * @param float $timeout [optional] = -1
-     * @return int|false
      */
-    public static function waitEvent($fd, int $events = SWOOLE_EVENT_READ, float $timeout = -1)
+    public static function waitEvent($fd, int $events, float $timeout = -1): bool|int
     {
     }
 
-    /**
-     * @param mixed $handle [required]
-     * @param int $length [optional] = 0
-     */
-    public static function fread($handle, int $length = 0)
-    {
-    }
-
-    /**
-     * @param mixed $handle [required]
-     * @param string $data [required]
-     * @param int $length [optional] = 0
-     */
-    public static function fwrite($handle, string $data, int $length = 0)
-    {
-    }
-
-    /**
-     * @param mixed $handle [required]
-     */
-    public static function fgets($handle): string
+    public static function clearDNSCache(): void
     {
     }
 }

--- a/ide-helper/src/OpenSwoole/Event.php
+++ b/ide-helper/src/OpenSwoole/Event.php
@@ -19,7 +19,7 @@ class Event
      * @param callable|null $writeCallback [optional] = null
      * @param int $flags [optional] = \SWOOLE_EVENT_READ
      */
-    public static function add($sock, ?callable $readCallback = null, ?callable $writeCallback = null, int $flags = SWOOLE_EVENT_READ)
+    public static function add($sock, ?callable $readCallback = null, ?callable $writeCallback = null, int $flags = SWOOLE_EVENT_READ): bool|int
     {
     }
 

--- a/ide-helper/src/OpenSwoole/Http/Request.php
+++ b/ide-helper/src/OpenSwoole/Http/Request.php
@@ -31,40 +31,29 @@ final class Request
     {
     }
 
-    /**
-     * @return string|bool
-     */
-    public function rawContent()
+    public function rawContent(): bool|string
     {
     }
 
-    /**
-     * @return string|bool
-     */
-    public function getContent()
+    public function getContent(): bool|string
     {
     }
 
-    /**
-     * @return string|bool
-     */
-    public function getData()
+    public function getData(): bool|string
     {
     }
 
     /**
      * @param array|null $options [required]
-     * @return Request|bool
      */
-    public static function create(?array $options)
+    public static function create(?array $options): Request|bool
     {
     }
 
     /**
      * @param string $data [required]
-     * @return int|false
      */
-    public function parse(string $data)
+    public function parse(string $data): int|false
     {
     }
 
@@ -72,10 +61,7 @@ final class Request
     {
     }
 
-    /**
-     * @return string|bool
-     */
-    public function getMethod()
+    public function getMethod(): bool|string
     {
     }
 }

--- a/ide-helper/src/OpenSwoole/Http/Response.php
+++ b/ide-helper/src/OpenSwoole/Http/Response.php
@@ -65,10 +65,7 @@ final class Response
     {
     }
 
-    /**
-     * @return Response|bool
-     */
-    public static function create($server = -1, int $fd = -1)
+    public static function create($server = -1, int $fd = -1): Response|bool
     {
     }
 
@@ -83,10 +80,7 @@ final class Response
     {
     }
 
-    /**
-     * @return \OpenSwoole\WebSocket\Frame|bool|string
-     */
-    public function recv(float $timeout = 0)
+    public function recv(float $timeout = 0): \OpenSwoole\WebSocket\Frame|bool|string
     {
     }
 

--- a/ide-helper/src/OpenSwoole/Process.php
+++ b/ide-helper/src/OpenSwoole/Process.php
@@ -146,7 +146,7 @@ class Process
     {
     }
 
-    public function start(): int
+    public function start(): bool|int
     {
     }
 
@@ -200,7 +200,7 @@ class Process
     {
     }
 
-    public function exportSocket()
+    public function exportSocket(): Coroutine\Socket|false
     {
     }
 

--- a/ide-helper/src/OpenSwoole/Process/Pool.php
+++ b/ide-helper/src/OpenSwoole/Process/Pool.php
@@ -56,9 +56,8 @@ class Pool
 
     /**
      * @param int $workerId [optional] = -1
-     * @return Process|false
      */
-    public function getProcess(int $workerId = -1)
+    public function getProcess(int $workerId = -1): Process|false
     {
     }
 

--- a/ide-helper/src/OpenSwoole/Server.php
+++ b/ide-helper/src/OpenSwoole/Server.php
@@ -117,17 +117,11 @@ class Server
     {
     }
 
-    /**
-     * @return false|Port
-     */
-    public function listen(string $host, int $port, int $sockType)
+    public function listen(string $host, int $port, int $sockType): false|Port
     {
     }
 
-    /**
-     * @return false|Port
-     */
-    public function addlistener(string $host, int $port, int $sockType)
+    public function addlistener(string $host, int $port, int $sockType): false|Port
     {
     }
 
@@ -206,31 +200,19 @@ class Server
     {
     }
 
-    /**
-     * @return bool|int
-     */
-    public function task($data, int $workerId = -1, ?callable $finishCallback = null)
+    public function task($data, int $workerId = -1, ?callable $finishCallback = null): bool|int
     {
     }
 
-    /**
-     * @return bool|string
-     */
-    public function taskwait($data, float $timeout = 0.5, int $workerId = -1)
+    public function taskwait($data, float $timeout = 0.5, int $workerId = -1): bool|string
     {
     }
 
-    /**
-     * @return bool|array
-     */
-    public function taskWaitMulti(array $tasks, float $timeout = 0.5)
+    public function taskWaitMulti(array $tasks, float $timeout = 0.5): bool|array
     {
     }
 
-    /**
-     * @return bool|array
-     */
-    public function taskCo(array $tasks, float $timeout = 0.5)
+    public function taskCo(array $tasks, float $timeout = 0.5): bool|array
     {
     }
 
@@ -246,24 +228,15 @@ class Server
     {
     }
 
-    /**
-     * @return false|array
-     */
-    public function heartbeat(bool $closeConn = false)
+    public function heartbeat(bool $closeConn = false): false|array
     {
     }
 
-    /**
-     * @return bool|array
-     */
-    public function getClientInfo(int $fd, int $reactorId = -1, bool $noCheckConn = false)
+    public function getClientInfo(int $fd, int $reactorId = -1, bool $noCheckConn = false): bool|array
     {
     }
 
-    /**
-     * @return bool|array
-     */
-    public function getClientList(int $startFd = 0, int $pageSize = 10)
+    public function getClientList(int $startFd = 0, int $pageSize = 10): bool|array
     {
     }
 
@@ -271,17 +244,11 @@ class Server
     {
     }
 
-    /**
-     * @return int|false
-     */
-    public function getWorkerPid(int $workerId = -1)
+    public function getWorkerPid(int $workerId = -1): int|false
     {
     }
 
-    /**
-     * @return bool|int
-     */
-    public function getWorkerStatus(int $workerId = -1)
+    public function getWorkerStatus(int $workerId = -1): bool|int
     {
     }
 
@@ -293,17 +260,11 @@ class Server
     {
     }
 
-    /**
-     * @return bool|array
-     */
-    public function connection_info(int $fd, int $reactorId = -1, bool $noCheckConn = false)
+    public function connection_info(int $fd, int $reactorId = -1, bool $noCheckConn = false): bool|array
     {
     }
 
-    /**
-     * @return bool|array
-     */
-    public function connection_list(int $startFd = 0, int $pageSize = 10)
+    public function connection_list(int $startFd = 0, int $pageSize = 10): bool|array
     {
     }
 
@@ -311,17 +272,11 @@ class Server
     {
     }
 
-    /**
-     * @return bool|int
-     */
-    public function addProcess(Process $process)
+    public function addProcess(Process $process): bool|int
     {
     }
 
-    /**
-     * @return string|array|false
-     */
-    public function stats(int $mode = 0)
+    public function stats(int $mode = 0): string|array|false
     {
     }
 

--- a/ide-helper/src/OpenSwoole/Server/Port.php
+++ b/ide-helper/src/OpenSwoole/Server/Port.php
@@ -82,4 +82,8 @@ final class Port
     public function setHandler($handler): bool
     {
     }
+
+    public function getSocket(): mixed
+    {
+    }
 }

--- a/ide-helper/src/OpenSwoole/Timer.php
+++ b/ide-helper/src/OpenSwoole/Timer.php
@@ -29,18 +29,16 @@ final class Timer
     /**
      * @param int $ms [required]
      * @param callable $callback [required]
-     * @return int|false
      */
-    public static function after(int $ms, callable $callback, ...$params)
+    public static function after(int $ms, callable $callback, ...$params): bool|int
     {
     }
 
     /**
      * @param int $ms [required]
      * @param callable $callback [required]
-     * @return int|false
      */
-    public static function tick(int $ms, callable $callback, ...$params)
+    public static function tick(int $ms, callable $callback, ...$params): bool|int
     {
     }
 


### PR DESCRIPTION
Update version constants (22.0.0-dev → 26.2.0), 
add reactor type constants (REACTOR_SELECT through REACTOR_IO_URING), SSL_SSLv3, and HAVE_DEBUG. 
Add native PHP return types across all stub classes, refactor PostgreSQL to the new two-class API (PostgreSQL + PostgreSQLStatement), 
add new methods (clearDNSCache, run, sslHandshake, getSocket), r
emove deprecated methods (suspend, getuid, fread/fwrite/fgets), 
and fix parameter names (usleep microseconds).