### PR TITLE
Fixed multipart/form-data key multiple files

### DIFF
--- a/core/src/Psr/ServerRequest.php
+++ b/core/src/Psr/ServerRequest.php
@@ -152,13 +152,26 @@ class ServerRequest extends Request implements ServerRequestInterface
 
         if (isset($request->files)) {
             foreach ($request->files as $name => $fileData) {
-                $files[$name] = new UploadedFile(
-                    Stream::createStreamFromFile($fileData['tmp_name']),
-                    $fileData['size'],
-                    $fileData['error'],
-                    $fileData['name'],
-                    $fileData['type']
-                );
+                if (isset($fileData[0]) && is_array($fileData[0])) {
+                    $files[$name] = [];
+                    foreach ($fileData as $singleFile) {
+                        $files[$name][] = new UploadedFile(
+                            Stream::createStreamFromFile($singleFile['tmp_name']),
+                            $singleFile['size'],
+                            $singleFile['error'],
+                            $singleFile['name'],
+                            $singleFile['type']
+                        );
+                    }
+                } else {
+                    $files[$name] = new UploadedFile(
+                        Stream::createStreamFromFile($fileData['tmp_name']),
+                        $fileData['size'],
+                        $fileData['error'],
+                        $fileData['name'],
+                        $fileData['type']
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #95 

When you try to upload multiple files on the same key, example with postman:
<img width="648" height="321" alt="image" src="https://github.com/user-attachments/assets/25fa1cd9-f76b-4861-9109-71444820a709" />

Current implementation fails because it expects `request->files` to be one-dimensional array but it actually is something like this:
```php
[
    "files" => [
        0 => [ file 1...]
        1 => [ file 1...]
    ]
]
```

Result:
```log
files_openswoole    | [2026-06-08T12:36:30]:WARNING: E_WARNING: Undefined array key "tmp_name" {
files_openswoole    |     "code": 2,
files_openswoole    |     "message": "Undefined array key \"tmp_name\"",
files_openswoole    |     "file": "/app/vendor/openswoole/core/src/Psr/ServerRequest.php",
files_openswoole    |     "line": 156
files_openswoole    | }
files_openswoole    | 
files_openswoole    | Fatal error: Uncaught TypeError: OpenSwoole\Core\Psr\Stream::createStreamFromFile(): Argument #1 ($filename) must be of type string, null given, called in /app/vendor/openswoole/core/src/Psr/ServerRequest.php on line 156 and defined in /app/vendor/openswoole/core/src/Psr/Stream.php:258
files_openswoole    | Stack trace:
files_openswoole    | #0 /app/vendor/openswoole/core/src/Psr/ServerRequest.php(156): OpenSwoole\Core\Psr\Stream::createStreamFromFile(NULL)
files_openswoole    | #1 /app/server.php(198): OpenSwoole\Core\Psr\ServerRequest::from(Object(OpenSwoole\Http\Request))
files_openswoole    | #2 [internal function]: {closure:/app/server.php:197}(Object(OpenSwoole\Http\Request), Object(OpenSwoole\Http\Response))
files_openswoole    | #3 {main}
files_openswoole    |   thrown in /app/vendor/openswoole/core/src/Psr/Stream.php on line 258
```

According to the official PSR-7 documentation for `ServerRequestInterface::getUploadedFiles()`:
> This method returns upload metadata in a normalized tree, with each leaf an instance of Psr\Http\Message\UploadedFileInterface.

And:
> The return value of this method MUST be a nested array of UploadedFileInterface instances, matching the structure of $_FILES.

Also this change should be backward compatibility for single-file uploads.